### PR TITLE
Sugerencias para Español mas neutro.

### DIFF
--- a/t9n/es.coffee
+++ b/t9n/es.coffee
@@ -6,36 +6,36 @@ es =
   add: "agregar"
   and: "y"
   back: "atrás"
-  changePassword: "Cambiar Contraseña"
-  choosePassword: "Eligir Contraseña"
-  clickAgree: "Si haces clic en Sucribir estas de acuerdo con la"
+  changePassword: "Cambiar contraseña"
+  choosePassword: "Eligir contraseña"
+  clickAgree: "Al hacer clic en Sucribir apruebas la"
   configure: "Disposición"
   createAccount: "Crear cuenta"
   currentPassword: "Contraseña actual"
-  dontHaveAnAccount: "No tenés una cuenta?"
+  dontHaveAnAccount: "No tienes una cuenta?"
   email: "Email"
-  emailAddress: "Dirección de Email"
-  emailResetLink: "Reiniciar Email"
-  forgotPassword: "Contraseña olvidada?"
-  ifYouAlreadyHaveAnAccount: "Si ya tenés una cuenta"
-  newPassword: "Nueva Contraseña"
-  newPasswordAgain: "Nueva Contraseña (repetición)"
+  emailAddress: "Dirección de email"
+  emailResetLink: "Reiniciar email"
+  forgotPassword: "Olvidó su contraseña?"
+  ifYouAlreadyHaveAnAccount: "Si ya tiene una cuenta"
+  newPassword: "Nueva contraseña"
+  newPasswordAgain: "Nueva contraseña (repetir)"
   optional: "Opcional"
   OR: "O"
   password: "Contraseña"
-  passwordAgain: "Contraseña (repetición)"
+  passwordAgain: "Contraseña (repetir)"
   privacyPolicy: "Póliza de Privacidad"
   remove: "remover"
   resetYourPassword: "Resetear tu contraseña"
-  setPassword: "Definir Contraseña"
+  setPassword: "Definir contraseña"
   sign: "Ingresar"
   signIn: "Entrar"
   signin: "entrar"
   signOut: "Salir"
   signUp: "Suscribir"
-  signupCode: "Codigo para suscribir"
+  signupCode: "Código de suscripción"
   signUpWithYourEmailAddress: "Suscribir con tu email"
-  terms: "Terminos de Uso"
+  terms: "Términos de uso"
   updateYourPassword: "Actualizar tu contraseña"
   username: "Usuario"
   usernameOrEmail: "Usuario o email"
@@ -44,20 +44,20 @@ es =
   info:
     emailSent: "Email enviado"
     emailVerified: "Email verificado"
-    passwordChanged: "Contraseña cambiado"
-    passwordReset: "Resetar Contraseña"
+    passwordChanged: "Contraseña cambiada"
+    passwordReset: "Resetear contraseña"
 
   error:
-    emailRequired: "Email es necesario."
-    minChar: "7 carácteres mínimo."
-    pwdsDontMatch: "Contraseñas no coninciden"
+    emailRequired: "El email es requerido."
+    minChar: "7 caracteres mínimo."
+    pwdsDontMatch: "Las contraseñas no coinciden"
     pwOneDigit: "mínimo un dígito."
     pwOneLetter: "mínimo una letra."
     signInRequired: "Debes iniciar sesión para hacer eso."
-    signupCodeIncorrect: "Código para suscribir no coincide."
-    signupCodeRequired: "Código para suscribir es necesario."
-    usernameIsEmail: "Usuario no puede ser Email."
-    usernameRequired: "Usuario es necesario."
+    signupCodeIncorrect: "El código de suscripción no coincide."
+    signupCodeRequired: "Se requiere el código de suscripción."
+    usernameIsEmail: "El usuario no puede ser el email."
+    usernameRequired: "Se requiere un usuario."
 
 
     accounts:
@@ -65,18 +65,18 @@ es =
       #---- accounts-base
       #"@" + domain + " email required":
       #"A login handler should return a result or undefined":
-      "Email already exists.": "Email ya existe."
-      "Email doesn't match the criteria.": "Email no coincide con los criterios."
+      "Email already exists.": "El email ya existe."
+      "Email doesn't match the criteria.": "El email no coincide con los criterios."
 #>    "Invalid login token":
 #>    "Login forbidden":
       #"Service " + options.service + " already configured":
 #>    "Service unknown":
 #>    "Unrecognized options for login request":
       "User validation failed": "No se ha podido validar el usuario"
-      "Username already exists.": "Usuario ya existe."
+      "Username already exists.": "El usuario ya existe."
 #>    "You are not logged in.":
-      "You've been logged out by the server. Please log in again.": "Has sido desconectado por el servidor. Por favor ingresa otra vez."
-      "Your session has expired. Please log in again.": "Tu session ha expirado. Por favor ingresa otra vez."
+      "You've been logged out by the server. Please log in again.": "Has sido desconectado por el servidor. Por favor ingresa de nuevo."
+      "Your session has expired. Please log in again.": "Tu sesión ha expirado. Por favor ingresa de nuevo."
 
 
       #---- accounts-oauth
@@ -88,19 +88,19 @@ es =
 
 
       #---- accounts-password
-      "Incorrect password": "Contraseña no válida"
+      "Incorrect password": "Contraseña inválida"
 #>    "Invalid email":
-      "Must be logged in": "Hay que ingresar"
+      "Must be logged in": "Debes ingresar"
       "Need to set a username or email": "Tienes que especificar un usuario o un email"
 #>    "old password format":
 #>    "Password may not be empty":
       "Signups forbidden": "Registro prohibido"
       "Token expired": "Token expirado"
-      "Token has invalid email address": "Token contiene un Email inválido"
+      "Token has invalid email address": "Token contiene un email inválido"
       "User has no password set": "Usuario no tiene contraseña"
       "User not found": "Usuario no encontrado"
-      "Verify email link expired": "Enlace para verificar el Email ha expirado"
-      "Verify email link is for unknown address": "Enlace para verificar el Email contiene una dirección desconocida"
+      "Verify email link expired": "El enlace para verificar el email ha expirado"
+      "Verify email link is for unknown address": "El enlace para verificar el email contiene una dirección desconocida"
 
       #---- match
 #>    "Match failed":


### PR DESCRIPTION
Algunos cambios:
- Palabras no capitalizadas ("Cambiar contraseña" en vez de "Cambiar Contraseña")
  ya que no es natural en castellano.
- Algunas palabras mas neutrales.
- Acentuaciones.
