### PR TITLE
Fixed language code

### DIFF
--- a/t9n/zh_cn.coffee
+++ b/t9n/zh_cn.coffee
@@ -111,4 +111,4 @@ zh_cn =
       "Unknown error": "未知错误"
 
 
-T9n.map "zh-cn", zh_cn
+T9n.map "zh_cn", zh_cn


### PR DESCRIPTION
all other similar cases are using `_` instead of `-`.
So it should be `zn_ch` and not `zn-ch`.