### PR TITLE
add code compatible with IETF language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ da     | Danish                   | LarsBuur
 de     | German                  | softwarerero, robhunt3r, sclausen, sarasate
 el     | Greek                   | mutil
 es     | Spanish                 | softwarerero, robhunt3r
-es_ES  | Spanish for Spain       | maomorales
+es_ES / es-ES  | Spanish for Spain       | maomorales
 fa     | Farsi                   | pajooh
 fr     | French                  | djhi
 he     | Hebrew                  | noamyoungerm
@@ -116,10 +116,10 @@ ja     | Japanese                | y-ich
 kh     | Khmer                   | yuomtheara
 ko     | Korean                  | candicom, buo
 nl     | Dutch                   | willemx, louwers
-no_NB  | Norwegian bokmål        | kjetilge
+no_NB / no-NB  | Norwegian bokmål        | kjetilge
 pl     | Polish                  | pwldp, wareczek
 pt     | Portuguese (Brasil)     | alanmeira, Tadeu Caldararo
-pt_PT  | Portuguese (Portugal)   | tdbs
+pt_PT / pt-PT  | Portuguese (Portugal)   | tdbs
 ro     | Romanian                | alexhuszar
 ru     | Russian                 | timtch
 sk     | Slovak                  | MartinBucko, aladinko
@@ -128,10 +128,11 @@ sv     | Swedish                 | timbrandin
 tr     | Turkish                 | serkandurusoy
 uk     | Ukrainian               | SkeLLLa
 vi     | Vietnamese              | olragon
-zh_cn  | Simplified Chinese      | laosb
-zh_hk  | Hong Kong Chinese       | daveeel
-zh_tw  | Taiwan Chinese          | victorleungtw
+zh_cn / zh-CN  | Simplified Chinese      | laosb
+zh_hk / zh-HK  | Hong Kong Chinese       | daveeel
+zh_tw / zh-TW  | Taiwan Chinese          | victorleungtw
 
+Note: "xx" or "xx-XX" is the [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) standard format.
 
 # Send only some language files to the client (new in version 1.1.0)
 If you have a need to reduce bandwidth you can specify which languages to send to the client by setting an environment variable like ```T9N_LANGUAGES='es,de'```. Now only Spanish and German should go over the wire instead of all translations.

--- a/t9n/es_ES.coffee
+++ b/t9n/es_ES.coffee
@@ -110,3 +110,4 @@ es_ES =
 
 
 T9n.map "es_ES", es_ES
+T9n.map "es-ES", es_ES

--- a/t9n/no_NB.coffee
+++ b/t9n/no_NB.coffee
@@ -112,3 +112,4 @@ no_NB =
 
 
 T9n.map "no_NB", no_NB
+T9n.map "no-NB", no_NB

--- a/t9n/pt_PT.coffee
+++ b/t9n/pt_PT.coffee
@@ -112,3 +112,4 @@ pt_PT =
 
 
 T9n.map "pt_PT", pt_PT
+T9n.map "pt-PT", pt_PT

--- a/t9n/zh_cn.coffee
+++ b/t9n/zh_cn.coffee
@@ -112,3 +112,4 @@ zh_cn =
 
 
 T9n.map "zh_cn", zh_cn
+T9n.map "zh-CN", zh_cn

--- a/t9n/zh_hk.coffee
+++ b/t9n/zh_hk.coffee
@@ -112,3 +112,4 @@ zh_hk =
 
 
 T9n.map "zh_hk", zh_hk
+T9n.map "zh-HK", zh_hk

--- a/t9n/zh_tw.coffee
+++ b/t9n/zh_tw.coffee
@@ -112,3 +112,4 @@ zh_tw =
 
 
 T9n.map "zh_tw", zh_tw
+T9n.map "zh-TW", zh_tw


### PR DESCRIPTION
"xx" or "xx-XX" is the [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) standard format, while "xx_xx" is not. 
When we detect language with javascript ```window.navigator.language```, it always return IETF standard tag. Adding code compatible with IETF language tag, will avoid conversion every time.