### PR TITLE
Remove dependency on Blaze

### DIFF
--- a/package.js
+++ b/package.js
@@ -21,7 +21,7 @@ Package.on_use(function (api, where) {
   if (api.versionsFrom)
     api.versionsFrom("METEOR@1.0.1");
   api.add_files(FILES, ['client', 'server']);
-  api.use(['coffeescript', 'deps', 'blaze-html-templates@1.0.1'], ['client', 'server']);
+  api.use(['coffeescript', 'deps'], ['client', 'server']);
   api.export('T9n', ['client', 'server']);
 });
 


### PR DESCRIPTION
I can't see that you're using Blaze anywhere, so let's remove this and be able to use it without this dependency:

Related issue:
https://github.com/studiointeract/accounts-ui/issues/15