### PR TITLE
Update Chinese language names to fix "language zh does not exist"

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 DEFAULT_LANGUAGES = ['ar', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 
-  'es_ES', 'fa', 'fr', 'he', 'hr', 'hu', 'id', 'it', 'ja', 'kh', 'ko', 'nl', 'no_NB', 'pl', 'pt', 'pt_PT', 'ro', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'vi', 'zh_cn', 'zh_tw', 'zh_hk'];
+  'es_ES', 'fa', 'fr', 'he', 'hr', 'hu', 'id', 'it', 'ja', 'kh', 'ko', 'nl', 'no_NB', 'pl', 'pt', 'pt_PT', 'ro', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'vi', 'zh_CN', 'zh_TW', 'zh_HK'];
 
 LANGUAGES = DEFAULT_LANGUAGES;
 if(process.env.T9N_LANGUAGES) {

--- a/t9n/zh_CN.coffee
+++ b/t9n/zh_CN.coffee
@@ -1,7 +1,7 @@
 #Language: Simplified Chinese
 #Translators: laosb, ArthurPai
 
-zh_cn =
+zh_CN =
 
   add: "添加"
   and: "和"
@@ -120,5 +120,5 @@ zh_cn =
       "Unknown error": "未知错误"
 
 
-T9n.map "zh_cn", zh_cn
-T9n.map "zh-CN", zh_cn
+T9n.map "zh_CN", zh_CN
+T9n.map "zh-CN", zh_CN

--- a/t9n/zh_HK.coffee
+++ b/t9n/zh_HK.coffee
@@ -1,7 +1,7 @@
 #Language: Traditional Chinese (Hong Kong)
 #Translators: daveeel
 
-zh_hk =
+zh_HK =
 
   add: "新增"
   and: "和"
@@ -111,5 +111,5 @@ zh_hk =
       "Unknown error": "無法確認的系統問題"
 
 
-T9n.map "zh_hk", zh_hk
-T9n.map "zh-HK", zh_hk
+T9n.map "zh_HK", zh_HK
+T9n.map "zh-HK", zh_HK

--- a/t9n/zh_TW.coffee
+++ b/t9n/zh_TW.coffee
@@ -1,7 +1,7 @@
 #Language: Traditional Chinese
 #Translators: victorleungtw, ArthurPai
 
-zh_tw =
+zh_TW =
 
   add: "添加"
   and: "和"
@@ -121,5 +121,5 @@ zh_tw =
       "Unknown error": "未知錯誤"
 
 
-T9n.map "zh_tw", zh_tw
-T9n.map "zh-TW", zh_tw
+T9n.map "zh_TW", zh_TW
+T9n.map "zh-TW", zh_TW


### PR DESCRIPTION
Because of names, users would suffer "not exists" errors.
![image](https://cloud.githubusercontent.com/assets/2545261/15070938/8a091498-13ba-11e6-9888-af59a90e18f9.png)
This PR should be able to fix it.