### PR TITLE
Typo fix for error.signInRequired translation part 2

### DIFF
--- a/t9n/de.coffee
+++ b/t9n/de.coffee
@@ -97,7 +97,7 @@ de =
       #---- accounts-password
       "Incorrect password": "Falsches Passwort"
       "Invalid email": "Ungültige E-Mail Adresse"
-      "Must be logged in": "Ein Anmeldung ist erforderlich"
+      "Must be logged in": "Eine Anmeldung ist erforderlich"
       "Need to set a username or email": "Benutzername oder E-Mail Adresse müssen angegeben werden"
 #>    "old password format":
       "Password may not be empty": "Das Passwort darf nicht leer sein"


### PR DESCRIPTION
Didn't see there is another translate key with the same wording. Change of `signInRequired` didn't have an effect.