### PR TITLE
Fix deprecated API use in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "Almost i18n, with standard translations for basic meteor packages.",
-  version: "2.5.4",
+  version: "2.5.5",
   name: "softwarerero:accounts-t9n",
   git: "https://github.com/softwarerero/meteor-accounts-t9n.git",
 });
@@ -14,12 +14,12 @@ for (var i = 0; i < LANGUAGES.length; i++) {
   FILES.push('build/' + LANGUAGES[i] + '.js');
 }
 
-Package.on_use(function (api, where) {
-  api.add_files(FILES, ['client', 'server']);
+Package.onUse(function (api, where) {
+  api.addFiles(FILES, ['client', 'server']);
   api.export('T9n', ['client', 'server']);
 });
 
 
-Package.on_test(function (api) {
-  api.add_files(FILES, ['client', 'server']);
+Package.onTest(function (api) {
+  api.addFiles(FILES, ['client', 'server']);
 });


### PR DESCRIPTION
package.js is using long time deprecated API, that has been finally removed in Meteor 2.3. Here is a fix.